### PR TITLE
Fix open all dropdowns button and class selectors

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 function checkTriangleRotation() {
-  document.querySelectorAll('.category, .question').forEach(el => {
+  document.querySelectorAll('.parent, .middle, .question').forEach(el => {
     const before = window.getComputedStyle(el, '::before');
     const transform = before.getPropertyValue('transform');
     const isActive = el.classList.contains('active');
@@ -78,14 +78,19 @@ function resetFAQ() {
 }
 
 function openAllDropdowns() {
-  document.querySelectorAll('.category, .question').forEach(el => {
+  document.querySelectorAll('.parent, .middle, .question').forEach(el => {
     el.classList.add('active');
   });
+  checkTriangleRotation();
 }
 
 document.addEventListener('DOMContentLoaded', function() {
   const searchInput = document.getElementById('searchInput');
   const noResults = document.getElementById('noResultsMessage');
+  const openAllBtn = document.getElementById('openAllDropdownsBtn');
+  if (openAllBtn) {
+    openAllBtn.addEventListener('click', openAllDropdowns);
+  }
   searchInput.addEventListener('input', function () {
     const value = this.value.trim().toLowerCase();
     const allDropdowns = document.querySelectorAll('.parent, .middle, .question');


### PR DESCRIPTION
## Summary
- ensure triangle rotation and open-all logic target parent, middle, and question dropdowns
- wire up `Open All Dropdowns` button to invoke dropdown expansion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68935c9507a0832cba9653e9ab4dd324