### PR TITLE
Ensure default scrolling behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,10 +11,12 @@ body {
 }
 
 body.search-open {
-  /* revert scroll-margin-top */
+  /* Reset scroll-margin-top to the default value */
+  scroll-margin-top: initial;
 }
 html, body {
-  /* revert overflow-y: auto */
+  /* Ensure vertical scrolling remains enabled */
+  overflow-y: auto;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- Reset `scroll-margin-top` to default when the search UI is open
- Restore vertical scrolling on the root elements

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/FAQ/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68935e8c679c832cb91014d750907972